### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,11 @@
-FROM debian:latest
+FROM node:18-alpine
+
+COPY package*.json /usr/src/app
 
 WORKDIR /usr/src/app
-
-COPY package*.json ./
-
-RUN apt-get -y update
-RUN apt-get -y install curl gnupg
-RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -
-RUN apt-get -y install nodejs
 
 COPY . .
 
 EXPOSE 8080
-CMD [ "/bin/sh", "start.sh" ]
+
+CMD ["/bin/sh", "start.sh"]


### PR DESCRIPTION
There is an official Docker image for node.js: https://hub.docker.com/_/node/
So there is no need to install it manually.

I recommend building the image before merging.