### PR TITLE
Handle startup promises during bootstrap

### DIFF
--- a/source/main.js
+++ b/source/main.js
@@ -276,21 +276,28 @@ for (const handler of handlerFiles) {
   require(`${handlersPath}/${handler}`)(client);
 }
 
-// Checking for update from Github if in dev mode
-if (client.mode === "dev") updateChecker();
+const bootstrap = async () => {
+  // Checking for update from Github if in dev mode
+  if (client.mode === "dev") await updateChecker();
 
-// Start connecting to the server.
-client.logger.info("Connecting to the backend and logging in...");
+  // Start connecting to the server.
+  client.logger.info("Connecting to the backend and logging in...");
 
-initializeApp(client.configs.server);
+  initializeApp(client.configs.server);
 
-if (client.mode !== "start") {
-  connectDatabaseEmulator(
-    getDatabase(),
-    client.configs.emulators.database.host,
-    client.configs.emulators.database.port,
-  );
-}
+  if (client.mode !== "start") {
+    connectDatabaseEmulator(
+      getDatabase(),
+      client.configs.emulators.database.host,
+      client.configs.emulators.database.port,
+    );
+  }
 
-// Start logging in and working
-client.login(client.configs.token);
+  // Start logging in and working
+  await client.login(client.configs.token);
+};
+
+bootstrap().catch((error) => {
+  client.logger.fatal(error, "Failed to bootstrap the main client.");
+  process.exitCode = 1;
+});

--- a/source/shard.js
+++ b/source/shard.js
@@ -48,11 +48,14 @@ const manager = new ShardingManager("./source/main.js", {
   totalShards: "auto",
 });
 
-startScreen();
-if (mode !== "dev") updateChecker();
-if (mode === "start") systemMetricsSubmitter();
-if (mode === "start") statisticsSubmitter(manager);
-if (mode === "start") healthCheckSubmitter();
+const bootstrap = async () => {
+  startScreen();
+
+  if (mode !== "dev") await updateChecker();
+  if (mode === "start") systemMetricsSubmitter();
+  if (mode === "start") statisticsSubmitter(manager);
+  if (mode === "start") healthCheckSubmitter();
+};
 
 manager.on("shardCreate", (shard) => {
   const shardID = shard.id;
@@ -308,4 +311,9 @@ manager.on("shardCreate", (shard) => {
   });
 });
 
-manager.spawn();
+bootstrap()
+  .then(() => manager.spawn())
+  .catch((error) => {
+    child.fatal(error, "Failed to bootstrap the shard manager.");
+    process.exitCode = 1;
+  });


### PR DESCRIPTION
## Summary
- await the dev update check before the main client continues bootstrapping
- await the Discord login promise and fail startup cleanly if bootstrap rejects
- await shard bootstrap before spawning and log shard-manager startup failures explicitly

## Testing
- npx eslint source/main.js source/shard.js
- npx prettier --check source/main.js source/shard.js

Closes #334
Closes #335
